### PR TITLE
feat: add Express PostgreSQL backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+PORT=3000
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASS=sua_senha
+DB_NAME=smartcode
+JWT_SECRET=seu_segredo_super_secreto

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/config/db.js
+++ b/config/db.js
@@ -1,0 +1,15 @@
+const { Sequelize } = require('sequelize');
+
+const sequelize = new Sequelize(
+  process.env.DB_NAME,
+  process.env.DB_USER,
+  process.env.DB_PASS,
+  {
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT,
+    dialect: 'postgres',
+    logging: false,
+  }
+);
+
+module.exports = { sequelize };

--- a/controllers/animalController.js
+++ b/controllers/animalController.js
@@ -1,0 +1,49 @@
+const Animal = require('../models/Animal');
+
+exports.list = async (req, res) => {
+  const animais = await Animal.findAll();
+  return res.json(animais);
+};
+
+exports.get = async (req, res) => {
+  const animal = await Animal.findByPk(req.params.id);
+  if (!animal) {
+    return res.status(404).json({ message: 'Animal não encontrado' });
+  }
+  return res.json(animal);
+};
+
+exports.create = async (req, res) => {
+  try {
+    const animal = await Animal.create(req.body);
+    return res.status(201).json(animal);
+  } catch (err) {
+    return res.status(500).json({ error: 'Erro ao criar animal' });
+  }
+};
+
+exports.update = async (req, res) => {
+  const animal = await Animal.findByPk(req.params.id);
+  if (!animal) {
+    return res.status(404).json({ message: 'Animal não encontrado' });
+  }
+  try {
+    await animal.update(req.body);
+    return res.json(animal);
+  } catch (err) {
+    return res.status(500).json({ error: 'Erro ao atualizar animal' });
+  }
+};
+
+exports.remove = async (req, res) => {
+  const animal = await Animal.findByPk(req.params.id);
+  if (!animal) {
+    return res.status(404).json({ message: 'Animal não encontrado' });
+  }
+  try {
+    await animal.destroy();
+    return res.json({ message: 'Animal removido' });
+  } catch (err) {
+    return res.status(500).json({ error: 'Erro ao remover animal' });
+  }
+};

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,0 +1,58 @@
+const Usuario = require('../models/Usuario');
+const TokenRecuperacao = require('../models/TokenRecuperacao');
+const { hashSenha, compararSenha } = require('../utils/hashSenha');
+const gerarTokenJWT = require('../utils/gerarToken');
+const validarEmail = require('../utils/validarEmail');
+const crypto = require('crypto');
+
+exports.register = async (req, res) => {
+  const { nome, email, senha, tipo } = req.body;
+  try {
+    if (!validarEmail(email)) {
+      return res.status(400).json({ message: 'Email inválido' });
+    }
+    const existente = await Usuario.findOne({ where: { email } });
+    if (existente) {
+      return res.status(400).json({ message: 'Email já cadastrado' });
+    }
+    const senhaHash = await hashSenha(senha);
+    const usuario = await Usuario.create({ nome, email, senha: senhaHash, tipo });
+    return res.status(201).json({ id: usuario.id, nome: usuario.nome, email: usuario.email, tipo: usuario.tipo });
+  } catch (err) {
+    return res.status(500).json({ error: 'Erro no cadastro' });
+  }
+};
+
+exports.login = async (req, res) => {
+  const { email, senha } = req.body;
+  try {
+    const usuario = await Usuario.findOne({ where: { email } });
+    if (!usuario) {
+      return res.status(400).json({ message: 'Credenciais inválidas' });
+    }
+    const match = await compararSenha(senha, usuario.senha);
+    if (!match) {
+      return res.status(400).json({ message: 'Credenciais inválidas' });
+    }
+    const token = gerarTokenJWT({ id: usuario.id, tipo: usuario.tipo });
+    return res.json({ token });
+  } catch (err) {
+    return res.status(500).json({ error: 'Erro no login' });
+  }
+};
+
+exports.gerarToken = async (req, res) => {
+  const { email } = req.body;
+  try {
+    const usuario = await Usuario.findOne({ where: { email } });
+    if (!usuario) {
+      return res.status(400).json({ message: 'Usuário não encontrado' });
+    }
+    const token = crypto.randomBytes(20).toString('hex');
+    const validade = new Date(Date.now() + 60 * 60 * 1000);
+    await TokenRecuperacao.create({ userId: usuario.id, token, validade });
+    return res.json({ token });
+  } catch (err) {
+    return res.status(500).json({ error: 'Erro ao gerar token' });
+  }
+};

--- a/controllers/usuarioController.js
+++ b/controllers/usuarioController.js
@@ -1,0 +1,15 @@
+const Usuario = require('../models/Usuario');
+
+exports.me = async (req, res) => {
+  try {
+    const usuario = await Usuario.findByPk(req.userId, {
+      attributes: ['id', 'nome', 'email', 'tipo'],
+    });
+    if (!usuario) {
+      return res.status(404).json({ message: 'Usuário não encontrado' });
+    }
+    return res.json(usuario);
+  } catch (err) {
+    return res.status(500).json({ error: 'Erro ao buscar usuário' });
+  }
+};

--- a/middleware/adminMiddleware.js
+++ b/middleware/adminMiddleware.js
@@ -1,0 +1,6 @@
+module.exports = (req, res, next) => {
+  if (req.userTipo !== 'admin') {
+    return res.status(403).json({ message: 'Acesso restrito a administradores' });
+  }
+  next();
+};

--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,0 +1,20 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (req, res, next) => {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    return res.status(401).json({ message: 'Token não fornecido' });
+  }
+  const [scheme, token] = authHeader.split(' ');
+  if (scheme !== 'Bearer' || !token) {
+    return res.status(401).json({ message: 'Token inválido' });
+  }
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.userId = decoded.id;
+    req.userTipo = decoded.tipo;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Token inválido' });
+  }
+};

--- a/models/Animal.js
+++ b/models/Animal.js
@@ -1,0 +1,23 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../config/db');
+
+const Animal = sequelize.define('Animal', {
+  nome: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  nascimento: {
+    type: DataTypes.DATEONLY,
+    allowNull: false,
+  },
+  categoria: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  raca: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+});
+
+module.exports = Animal;

--- a/models/TokenRecuperacao.js
+++ b/models/TokenRecuperacao.js
@@ -1,0 +1,19 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../config/db');
+const Usuario = require('./Usuario');
+
+const TokenRecuperacao = sequelize.define('TokenRecuperacao', {
+  token: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  validade: {
+    type: DataTypes.DATE,
+    allowNull: false,
+  },
+});
+
+Usuario.hasMany(TokenRecuperacao, { foreignKey: 'userId' });
+TokenRecuperacao.belongsTo(Usuario, { foreignKey: 'userId' });
+
+module.exports = TokenRecuperacao;

--- a/models/Usuario.js
+++ b/models/Usuario.js
@@ -1,0 +1,24 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../config/db');
+
+const Usuario = sequelize.define('Usuario', {
+  nome: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+  },
+  senha: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  tipo: {
+    type: DataTypes.ENUM('admin', 'produtor'),
+    defaultValue: 'produtor',
+  },
+});
+
+module.exports = Usuario;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "smartcode-backend",
+  "version": "1.0.0",
+  "description": "Backend Node.js com Express e PostgreSQL usando Sequelize",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "seed": "node seed.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "pg": "^8.11.1",
+    "pg-hstore": "^2.3.4",
+    "sequelize": "^6.32.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  }
+}

--- a/routes/animalRoutes.js
+++ b/routes/animalRoutes.js
@@ -1,0 +1,12 @@
+const router = require('express').Router();
+const animalController = require('../controllers/animalController');
+const auth = require('../middleware/authMiddleware');
+const admin = require('../middleware/adminMiddleware');
+
+router.get('/', auth, animalController.list);
+router.get('/:id', auth, animalController.get);
+router.post('/', auth, animalController.create);
+router.put('/:id', auth, animalController.update);
+router.delete('/:id', auth, admin, animalController.remove);
+
+module.exports = router;

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+const authController = require('../controllers/authController');
+
+router.post('/login', authController.login);
+router.post('/register', authController.register);
+router.post('/token', authController.gerarToken);
+
+module.exports = router;

--- a/routes/usuarioRoutes.js
+++ b/routes/usuarioRoutes.js
@@ -1,0 +1,7 @@
+const router = require('express').Router();
+const usuarioController = require('../controllers/usuarioController');
+const auth = require('../middleware/authMiddleware');
+
+router.get('/me', auth, usuarioController.me);
+
+module.exports = router;

--- a/seed.js
+++ b/seed.js
@@ -1,0 +1,34 @@
+require('dotenv').config();
+const { sequelize } = require('./config/db');
+const Usuario = require('./models/Usuario');
+const { hashSenha } = require('./utils/hashSenha');
+
+const seed = async () => {
+  try {
+    await sequelize.sync({ force: true });
+    const adminSenha = await hashSenha('admin123');
+    const produtorSenha = await hashSenha('produtor123');
+
+    await Usuario.bulkCreate([
+      {
+        nome: 'Admin',
+        email: 'admin@smartcode.com',
+        senha: adminSenha,
+        tipo: 'admin',
+      },
+      {
+        nome: 'Produtor',
+        email: 'produtor@smartcode.com',
+        senha: produtorSenha,
+        tipo: 'produtor',
+      },
+    ]);
+    console.log('Seed concluído');
+  } catch (err) {
+    console.error('Erro no seed', err);
+  } finally {
+    await sequelize.close();
+  }
+};
+
+seed();

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+require('dotenv').config();
+const express = require('express');
+const app = express();
+const { sequelize } = require('./config/db');
+
+// Import models to ensure they are registered with Sequelize
+require('./models/Usuario');
+require('./models/Animal');
+require('./models/TokenRecuperacao');
+
+const authRoutes = require('./routes/authRoutes');
+const usuarioRoutes = require('./routes/usuarioRoutes');
+const animalRoutes = require('./routes/animalRoutes');
+
+app.use(express.json());
+
+app.use('/api/auth', authRoutes);
+app.use('/api/usuarios', usuarioRoutes);
+app.use('/api/animais', animalRoutes);
+
+const PORT = process.env.PORT || 3000;
+
+sequelize
+  .sync()
+  .then(() => {
+    app.listen(PORT, () => console.log(`Servidor rodando na porta ${PORT}`));
+  })
+  .catch((err) => {
+    console.error('Erro ao conectar ao banco:', err);
+  });

--- a/utils/gerarToken.js
+++ b/utils/gerarToken.js
@@ -1,0 +1,7 @@
+const jwt = require('jsonwebtoken');
+
+const gerarToken = (payload, expiresIn = '1h') => {
+  return jwt.sign(payload, process.env.JWT_SECRET, { expiresIn });
+};
+
+module.exports = gerarToken;

--- a/utils/hashSenha.js
+++ b/utils/hashSenha.js
@@ -1,0 +1,10 @@
+const bcrypt = require('bcrypt');
+
+const hashSenha = async (senha) => {
+  const salt = await bcrypt.genSalt(10);
+  return bcrypt.hash(senha, salt);
+};
+
+const compararSenha = (senha, hash) => bcrypt.compare(senha, hash);
+
+module.exports = { hashSenha, compararSenha };

--- a/utils/validarEmail.js
+++ b/utils/validarEmail.js
@@ -1,0 +1,3 @@
+const validarEmail = (email) => /\S+@\S+\.\S+/.test(email);
+
+module.exports = validarEmail;


### PR DESCRIPTION
## Summary
- set up Express server with Sequelize and JWT authentication
- add models, controllers and routes for users, animals and tokens
- include utilities, middleware and seed script for initial admin and produtor

## Testing
- `npm install` *(fails: 403 Forbidden - bcrypt)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff9a6551883289c49b9cdd40fe338