### PR TITLE
feat: add classic login screen

### DIFF
--- a/client/src/pages/Auth/Login.jsx
+++ b/client/src/pages/Auth/Login.jsx
@@ -1,47 +1,87 @@
-import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
-import jwtDecode from 'jwt-decode';
+import { motion } from 'framer-motion';
+import { useNavigate, Link } from 'react-router-dom';
+import jwt_decode from 'jwt-decode';
 import api from '../../api';
-import FrasesRotativas from '../../components/FrasesRotativas';
+import LoginInfoRotativo from '../../components/LoginInfoRotativo';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [senha, setSenha] = useState('');
-  const [mostrarSenha, setMostrarSenha] = useState(false);
+  const [carregando, setCarregando] = useState(false);
   const [lembrar, setLembrar] = useState(false);
+  const [mostrarSenha, setMostrarSenha] = useState(false);
+  const [erroEmail, setErroEmail] = useState('');
+  const [erroSenha, setErroSenha] = useState('');
   const navigate = useNavigate();
 
-  const handleLogin = async (e) => {
-    e.preventDefault();
-    try {
-      const response = await api.post('/auth/login', { email, senha });
-      const token = response.data.token;
-      localStorage.setItem('token', token);
-      const decoded = jwtDecode(token);
-      localStorage.setItem('user', JSON.stringify(decoded));
-      navigate('/dashboard');
-    } catch (error) {
-      alert('Erro ao fazer login. Verifique suas credenciais.');
+  useEffect(() => {
+    const salvo = localStorage.getItem('rememberEmail');
+    if (salvo) {
+      setEmail(salvo);
+      setLembrar(true);
     }
+  }, []);
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  const validar = () => {
+    const emailTrim = email.trim();
+    const senhaTrim = senha.trim();
+    setEmail(emailTrim);
+    setSenha(senhaTrim);
+    let ok = true;
+    if (!emailRegex.test(emailTrim)) {
+      setErroEmail('Email inválido');
+      ok = false;
+    } else {
+      setErroEmail('');
+    }
+    if (!senhaTrim) {
+      setErroSenha('Senha obrigatória');
+      ok = false;
+    } else {
+      setErroSenha('');
+    }
+    return ok;
   };
 
-  const inputStyle = {
-    width: '100%',
-    padding: '10px',
-    borderRadius: '8px',
-    border: '1px solid #ccc',
-  };
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!validar()) return;
+    try {
+      setCarregando(true);
+      const res = await api.post('/auth/login', {
+        email: email.trim(),
+        senha: senha.trim(),
+      });
 
-  const iconButtonStyle = {
-    position: 'absolute',
-    right: '10px',
-    top: '50%',
-    transform: 'translateY(-50%)',
-    background: 'none',
-    border: 'none',
-    cursor: 'pointer',
-    padding: 0,
+      if (res.status === 200 && res.data?.token) {
+        const token = res.data.token;
+        localStorage.setItem('token', token);
+
+        if (lembrar) {
+          localStorage.setItem('rememberEmail', email.trim());
+        } else {
+          localStorage.removeItem('rememberEmail');
+        }
+
+        const decoded = jwt_decode(token);
+        const isAdmin = decoded?.perfil === 'admin';
+        navigate(isAdmin ? '/admin' : '/inicio');
+      } else {
+        alert('Token não recebido.');
+      }
+    } catch (err) {
+      alert(
+        err.response?.data?.erro ||
+        err.response?.data?.message ||
+        'Email ou senha incorretos.'
+      );
+    } finally {
+      setCarregando(false);
+    }
   };
 
   return (
@@ -49,88 +89,161 @@ export default function Login() {
       style={{
         minHeight: '100vh',
         width: '100%',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
+        overflow: 'hidden',
         backgroundImage: "url('/icones/telafundo.png')",
         backgroundSize: 'cover',
         backgroundPosition: 'center',
-        margin: 0,
-        padding: 0,
+        backgroundRepeat: 'no-repeat',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: "'Inter', 'Poppins', sans-serif",
+        position: 'relative',
       }}
     >
-      <form
-        onSubmit={handleLogin}
+      <div
         style={{
-          backgroundColor: 'rgba(255,255,255,0.85)',
-          padding: '40px',
-          borderRadius: '20px',
-          boxShadow: '0 4px 10px rgba(0,0,0,0.1)',
-          maxWidth: '400px',
-          width: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '16px',
+          position: 'absolute',
+          top: '40px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          textAlign: 'center',
+          color: '#fff',
+          textShadow: '0 1px 4px rgba(0,0,0,0.5)',
+          zIndex: 5,
         }}
       >
-        <h2 style={{ textAlign: 'center' }}>SmartMilk</h2>
-        <p className="text-center text-sm text-gray-600">Bem-vindo ao Gestão Leiteira</p>
-        <FrasesRotativas />
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="E-mail"
-          style={inputStyle}
-        />
-        <div style={{ position: 'relative' }}>
-          <input
-            type={mostrarSenha ? 'text' : 'password'}
-            value={senha}
-            onChange={(e) => setSenha(e.target.value)}
-            placeholder="Senha"
-            style={{ ...inputStyle, paddingRight: '40px' }}
-          />
-          <button
-            type="button"
-            onClick={() => setMostrarSenha((s) => !s)}
-            style={iconButtonStyle}
-          >
-            {mostrarSenha ? <EyeOff size={18} /> : <Eye size={18} />}
-          </button>
-        </div>
-        <label style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px' }}>
-          <input
-            type="checkbox"
-            checked={lembrar}
-            onChange={(e) => setLembrar(e.target.checked)}
-          />
-          <span>Lembrar-me</span>
-        </label>
-        <button
-          type="submit"
+        <h1
           style={{
-            backgroundColor: '#1e3a8a',
-            color: '#fff',
-            border: 'none',
-            borderRadius: '30px',
-            padding: '10px',
-            width: '60%',
-            margin: '20px auto 0',
-            cursor: 'pointer',
-            transition: 'background 0.3s',
+            fontFamily: "'Poppins', sans-serif",
+            fontSize: '3rem',
+            fontWeight: 700,
+            margin: 0,
+            marginBottom: '5px',
           }}
-          onMouseEnter={(e) => (e.target.style.backgroundColor = '#2563eb')}
-          onMouseLeave={(e) => (e.target.style.backgroundColor = '#1e3a8a')}
         >
-          Entrar
-        </button>
-        <div style={{ textAlign: 'center', fontSize: '14px' }}>
-          <Link to="/recuperar">Esqueceu a senha?</Link>
-          <br />
-          Não tem conta? <Link to="/cadastro">Cadastrar-se</Link>
+          SmartMilk - GESTÃO LEITEIRA
+        </h1>
+        <h2
+          style={{
+            fontFamily: "'Dancing Script', cursive",
+            fontSize: '2rem',
+            fontWeight: 500,
+            color: '#ffd43b',
+            textShadow: '1px 1px 3px rgba(0,0,0,0.4)',
+            margin: 0,
+          }}
+        >
+          Feito por quem vive no campo.
+        </h2>
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%', flex: 1, marginTop: '120px' }}>
+        <motion.div style={{ flex: 1 }} initial={{ opacity: 0, y: -50 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 1.2 }}>
+          <LoginInfoRotativo />
+        </motion.div>
+
+        <div style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+          <motion.div initial={{ opacity: 0, x: -100 }} animate={{ opacity: 1, x: 0 }} transition={{ duration: 1.2 }}>
+            <div style={{
+              backgroundColor: 'rgba(255, 255, 255, 0.7)',
+              padding: '40px',
+              borderRadius: '20px',
+              boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+              maxWidth: '500px',
+              width: '100%',
+            }}>
+              <p style={{ fontSize: '1.5rem', fontWeight: 600, fontFamily: "'Poppins', sans-serif", marginBottom: '10px', textAlign: 'center' }}>
+                Bem-vindo ao SmartMilk!
+              </p>
+              <h2 style={{ color: '#1e3a8a' }} className="text-xl font-bold text-center mb-4">Login</h2>
+              <form onSubmit={handleSubmit} onKeyDown={(e) => e.key === 'Enter' && handleSubmit(e)} className="flex flex-col gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+                  <div className="input-senha-container">
+                    <input
+                      type="email"
+                      placeholder="Digite seu e-mail"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      className="input-senha"
+                    />
+                  </div>
+                  {erroEmail && (
+                    <p className="text-red-600 text-sm mt-1">{erroEmail}</p>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Senha</label>
+                  <div className="input-senha-container">
+                    <input
+                      type={mostrarSenha ? 'text' : 'password'}
+                      placeholder="Digite sua senha"
+                      value={senha}
+                      onChange={(e) => setSenha(e.target.value)}
+                      className="input-senha input-senha-olho"
+                    />
+                    <button type="button" onClick={() => setMostrarSenha(!mostrarSenha)} className="botao-olho">
+                      {mostrarSenha ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </button>
+                  </div>
+                  {erroSenha && (
+                    <p className="text-red-600 text-sm mt-1">{erroSenha}</p>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <input id="lembrar" type="checkbox" checked={lembrar} onChange={(e) => setLembrar(e.target.checked)} />
+                  <label htmlFor="lembrar" className="text-sm">Lembrar-me</label>
+                </div>
+
+                <button
+                  type="submit"
+                  style={{
+                    background: 'linear-gradient(90deg, #1e3a8a, #3b82f6)',
+                    color: '#fff',
+                    padding: '12px 24px',
+                    borderRadius: '30px',
+                    border: 'none',
+                    fontSize: '1.1rem',
+                    fontWeight: '600',
+                    cursor: 'pointer',
+                    transition: 'all 0.3s ease',
+                    boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
+                  }}
+                  onMouseOver={(e) => (e.target.style.background = '#1e40af')}
+                  onMouseOut={(e) => (e.target.style.background = 'linear-gradient(90deg, #1e3a8a, #3b82f6)')}
+                >
+                  Entrar
+                </button>
+
+                <div className="text-right">
+                  <Link to="/esqueci-senha" className="text-sm text-blue-600 hover:underline">
+                    Esqueceu a senha?
+                  </Link>
+                </div>
+              </form>
+
+              <p className="text-center text-sm text-gray-600 mt-4 font-light">
+                Não tem conta?{' '}
+                <Link to="/escolher-plano" className="text-blue-600 hover:underline">
+                  Cadastrar-se
+                </Link>
+              </p>
+            </div>
+          </motion.div>
         </div>
-      </form>
+      </div>
+
+      <footer style={{
+        backgroundColor: 'rgba(255, 255, 255, 0.6)',
+        padding: '8px',
+        textAlign: 'center',
+        fontSize: '0.8rem',
+        width: '100%',
+      }}>
+        Versão 1.0.0 | © Gestão Leiteira 2025
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- recreate original login page with animations, remember-me, and token-based redirect

## Testing
- `npm test`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_6890a256feb0832885213528ebbef932