### PR TITLE
style: refine login layout

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SmartCow</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Poppins:wght@300;400;600;700&family=Pacifico&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,5 +1,5 @@
 body {
-  font-family: sans-serif;
+  font-family: 'Inter', 'Poppins', sans-serif;
   margin: 0;
   padding: 0;
 }

--- a/client/src/pages/Auth/Login.jsx
+++ b/client/src/pages/Auth/Login.jsx
@@ -124,10 +124,10 @@ export default function Login() {
         </h1>
         <h2
           style={{
-            fontFamily: "'Dancing Script', cursive",
+            fontFamily: "'Pacifico', cursive",
             fontSize: '2rem',
             fontWeight: 500,
-            color: '#ffd43b',
+            color: '#facc15',
             textShadow: '1px 1px 3px rgba(0,0,0,0.4)',
             margin: 0,
           }}
@@ -139,22 +139,24 @@ export default function Login() {
       <div
         style={{
           display: 'flex',
-          justifyContent: 'space-between',
+          justifyContent: 'center',
+          alignItems: 'center',
           width: '100%',
           flex: 1,
           marginTop: '120px',
+          gap: '40px',
         }}
       >
         <motion.div
-          style={{ flex: 1 }}
+          style={{ display: 'flex', justifyContent: 'center' }}
           initial={{ opacity: 0, y: -50 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 1.2, ease: 'easeOut' }}
         >
-           <CarrosselLogos /> {/* ou o componente novo que você usa agora */}
+          <CarrosselLogos />
         </motion.div>
 
-        <div style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
           <motion.div
             initial={{ opacity: 0, x: -100 }}
             animate={{ opacity: 1, x: 0 }}
@@ -166,8 +168,7 @@ export default function Login() {
                 padding: '40px',
                 borderRadius: '20px',
                 boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
-                maxWidth: '500px',
-                width: '100%',
+                width: '420px',
               }}
             >
               <p
@@ -182,46 +183,61 @@ export default function Login() {
                 Bem-vindo ao SmartMilk!
               </p>
 
-              <h2 className="text-xl font-bold text-center mb-4" style={{ color: '#1e3a8a' }}>
+              <h2
+                style={{
+                  textAlign: 'center',
+                  fontWeight: 700,
+                  color: '#1e3a8a',
+                  marginBottom: '16px',
+                }}
+              >
                 Login
               </h2>
 
-              <form onSubmit={handleSubmit} onKeyDown={(e) => e.key === 'Enter' && handleSubmit(e)} className="flex flex-col gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                   <div style={{ position: 'relative' }}>
+              <form
+                onSubmit={handleSubmit}
+                onKeyDown={(e) => e.key === 'Enter' && handleSubmit(e)}
+                style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', gap: '16px' }}
+              >
+                <div style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                  <label style={{ fontSize: '0.9rem', alignSelf: 'flex-start' }}>Email</label>
+                  <div style={{ position: 'relative', width: '100%', maxWidth: '360px' }}>
                     <input
                       type="email"
                       placeholder="Digite seu e-mail"
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
-                       style={{
+                      style={{
                         width: '100%',
-                        padding: '12px',
+                        maxWidth: '360px',
+                        height: '40px',
+                        padding: '0 12px',
                         borderRadius: '20px',
                         border: '1px solid #ccc',
                       }}
                     />
                   </div>
-                  {erroEmail && <p className="text-red-600 text-sm mt-1">{erroEmail}</p>}
+                  {erroEmail && <p style={{ color: 'red', fontSize: '0.875rem', marginTop: '4px' }}>{erroEmail}</p>}
                 </div>
 
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Senha</label>
-                   <div style={{ position: 'relative' }}>
+                <div style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                  <label style={{ fontSize: '0.9rem', alignSelf: 'flex-start' }}>Senha</label>
+                  <div style={{ position: 'relative', width: '100%', maxWidth: '360px' }}>
                     <input
                       type={mostrarSenha ? 'text' : 'password'}
                       placeholder="Digite sua senha"
                       value={senha}
                       onChange={(e) => setSenha(e.target.value)}
-                       style={{
+                      style={{
                         width: '100%',
-                        padding: '12px 40px 12px 12px',
+                        maxWidth: '360px',
+                        height: '40px',
+                        padding: '0 40px 0 12px',
                         borderRadius: '20px',
                         border: '1px solid #ccc',
                       }}
                     />
-                     <button
+                    <button
                       type="button"
                       onClick={() => setMostrarSenha(!mostrarSenha)}
                       style={{
@@ -237,47 +253,71 @@ export default function Login() {
                       {mostrarSenha ? <EyeOff size={18} /> : <Eye size={18} />}
                     </button>
                   </div>
-                  {erroSenha && <p className="text-red-600 text-sm mt-1">{erroSenha}</p>}
+                  {erroSenha && <p style={{ color: 'red', fontSize: '0.875rem', marginTop: '4px' }}>{erroSenha}</p>}
                 </div>
 
-                <div className="flex items-center gap-2">
-                  <input id="lembrar" type="checkbox" checked={lembrar} onChange={(e) => setLembrar(e.target.checked)} />
-                  <label htmlFor="lembrar" className="text-sm">Lembrar-me</label>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    width: '100%',
+                    maxWidth: '360px',
+                    alignSelf: 'flex-start',
+                  }}
+                >
+                  <input
+                    id="lembrar"
+                    type="checkbox"
+                    checked={lembrar}
+                    onChange={(e) => setLembrar(e.target.checked)}
+                  />
+                  <label htmlFor="lembrar" style={{ fontSize: '0.9rem' }}>
+                    Lembrar-me
+                  </label>
                 </div>
 
                 <button
                   type="submit"
                   style={{
+                    width: '100%',
+                    maxWidth: '360px',
+                    height: '42px',
                     background: 'linear-gradient(90deg, #1e3a8a, #3b82f6)',
                     color: '#fff',
-                    padding: '12px 24px',
-                    borderRadius: '30px',
                     border: 'none',
-                    fontSize: '1.1rem',
-                    fontWeight: '600',
+                    borderRadius: '25px',
+                    fontSize: '1rem',
+                    fontWeight: 700,
                     cursor: 'pointer',
-                    transition: 'all 0.3s ease',
+                    transition: 'background 0.3s ease',
                     boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
                   }}
-                  onMouseOver={(e) => (e.target.style.background = '#1e40af')}
-                  onMouseOut={(e) => (e.target.style.background = 'linear-gradient(90deg, #1e3a8a, #3b82f6)')}
+                  onMouseOver={(e) => (e.target.style.background = 'linear-gradient(90deg, #1e40af, #1e3a8a)')}
+                  onMouseOut={(e) =>
+                    (e.target.style.background = 'linear-gradient(90deg, #1e3a8a, #3b82f6)')
+                  }
                 >
                   Entrar
                 </button>
 
-                <div className="text-right">
-                  <Link to="/esqueci-senha" className="text-sm text-blue-600 hover:underline">
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    width: '100%',
+                    maxWidth: '360px',
+                    fontSize: '0.85rem',
+                  }}
+                >
+                  <Link to="/esqueci-senha" style={{ textDecoration: 'underline', color: '#1e3a8a' }}>
                     Esqueceu a senha?
+                  </Link>
+                  <Link to="/escolher-plano" style={{ textDecoration: 'underline', color: '#1e3a8a' }}>
+                    Cadastrar-se
                   </Link>
                 </div>
               </form>
-
-              <p className="text-center text-sm text-gray-600 mt-4 font-light">
-                Não tem conta?{' '}
-                <Link to="/escolher-plano" className="text-blue-600 hover:underline">
-                  Cadastrar-se
-                </Link>
-              </p>
             </div>
           </motion.div>
         </div>


### PR DESCRIPTION
## Summary
- center login form and widen modal
- restyle inputs, button and links for improved UX
- add Google font imports and global font settings

## Testing
- `npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c71699448328b7db8c5efa4536d6