### PR TITLE
Recriar tela de escolha de plano para cadastro

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import Cadastro from './pages/Auth/Cadastro';
 import VerificarEmail from './pages/Auth/VerificarEmail';
 import EsqueciSenha from './pages/Auth/EsqueciSenha';
 import Logout from './pages/Auth/Logout';
+import EscolherPlanoCadastro from './pages/EscolherPlanoCadastro';
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="/" element={<Login />} />
         <Route path="/login" element={<Login />} />
         <Route path="/cadastro" element={<Cadastro />} />
+        <Route path="/escolher-plano" element={<EscolherPlanoCadastro />} />
         <Route path="/verificar" element={<VerificarEmail />} />
         <Route path="/recuperar" element={<EsqueciSenha />} />
         <Route path="/logout" element={<Logout />} />

--- a/client/src/components/ModalPlanoSelecionado.jsx
+++ b/client/src/components/ModalPlanoSelecionado.jsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+
+function ModalPlanoSelecionado({ plano, finalizar, onClose }) {
+  const [formaPagamento, setFormaPagamento] = useState('cartao');
+
+  const handleConfirmar = () => {
+    finalizar(formaPagamento);
+    onClose();
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: '#fff',
+          padding: '20px',
+          borderRadius: '10px',
+          width: '90%',
+          maxWidth: '400px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+        }}
+      >
+        <h2 style={{ textAlign: 'center' }}>{plano.nome}</h2>
+        <p style={{ textAlign: 'center', fontWeight: 'bold' }}>{plano.preco}</p>
+        <select
+          value={formaPagamento}
+          onChange={(e) => setFormaPagamento(e.target.value)}
+          style={{ padding: '8px', borderRadius: '8px', border: '1px solid #ccc' }}
+        >
+          <option value="cartao">Cartão de crédito</option>
+          <option value="boleto">Boleto</option>
+          <option value="pix">Pix</option>
+        </select>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
+          <button className="botao-cancelar" onClick={onClose}>
+            Cancelar
+          </button>
+          <button className="botao-acao" onClick={handleConfirmar}>
+            Confirmar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ModalPlanoSelecionado;

--- a/client/src/pages/EscolherPlanoCadastro.jsx
+++ b/client/src/pages/EscolherPlanoCadastro.jsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import { Gift, Star, Rocket, Crown } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import api from '../api';
+import ModalPlanoSelecionado from '../components/ModalPlanoSelecionado';
+import '../styles/planos.css';
+
+const planos = [
+  {
+    id: 'teste_gratis',
+    nome: 'Teste Grátis',
+    descricao: 'Aproveite 7 dias gratuitamente',
+    preco: 'Grátis',
+    beneficios: ['Acesso limitado', 'Sem suporte', 'Expira após 7 dias'],
+    cor: '#3b82f6',
+    Icon: Gift,
+  },
+  {
+    id: 'basico',
+    nome: 'Básico',
+    descricao: 'Funcionalidades essenciais',
+    preco: 'R$19,90/mês',
+    beneficios: ['Controle de tarefas', 'Cadastro de vacas', 'Exportação de dados'],
+    cor: '#10b981',
+    Icon: Star,
+  },
+  {
+    id: 'intermediario',
+    nome: 'Intermediário',
+    descricao: 'Inclui bezerras, reprodução e estoque',
+    preco: 'R$29,90/mês',
+    beneficios: ['Tudo do Básico', 'Gestão de bezerras', 'Reprodução avançada'],
+    cor: '#f59e0b',
+    Icon: Rocket,
+  },
+  {
+    id: 'completo',
+    nome: 'Completo',
+    descricao: 'Relatórios, gráficos e tudo incluso',
+    preco: 'R$39,90/mês',
+    beneficios: ['Tudo do Intermediário', 'Gráficos completos', 'Relatórios PDF'],
+    cor: '#8b5cf6',
+    Icon: Crown,
+  },
+];
+
+function EscolherPlanoCadastro() {
+  const [planoSelecionado, setPlanoSelecionado] = useState(null);
+  const [mostrarModal, setMostrarModal] = useState(false);
+  const navigate = useNavigate();
+
+  const selecionarPlano = (plano) => {
+    setPlanoSelecionado(plano);
+    if (plano.id === 'teste_gratis') {
+      setMostrarModal(false);
+    } else {
+      setMostrarModal(true);
+    }
+  };
+
+  const cancelar = () => {
+    setPlanoSelecionado(null);
+    setMostrarModal(false);
+  };
+
+  const finalizar = async (formaPagamento = null) => {
+    if (!planoSelecionado) return;
+    try {
+      await api.post('/auth/finalizar-cadastro', {
+        token: localStorage.getItem('tokenCadastro'),
+        plano: planoSelecionado.id,
+        formaPagamento,
+      });
+      localStorage.clear();
+      navigate('/login');
+    } catch (err) {
+      console.error('Erro ao finalizar cadastro', err);
+    }
+  };
+
+  return (
+    <div className="pagina-escolher-plano">
+      <div className="painel-planos">
+        <h1>Escolha seu Plano</h1>
+        <p>Selecione o plano desejado para concluir o cadastro.</p>
+        <div className="grid-planos">
+          {planos.map((plano) => (
+            <div key={plano.id} className="card-plano-modern">
+              <plano.Icon size={40} color={plano.cor} />
+              <h3>{plano.nome}</h3>
+              <p>{plano.descricao}</p>
+              <ul className="lista-beneficios">
+                {plano.beneficios.map((b) => (
+                  <li key={b}>{b}</li>
+                ))}
+              </ul>
+              <button
+                className="btn-escolher-moderno"
+                style={{ backgroundColor: plano.cor }}
+                onClick={() => selecionarPlano(plano)}
+              >
+                Escolher
+              </button>
+            </div>
+          ))}
+        </div>
+        {planoSelecionado?.id === 'teste_gratis' && (
+          <div className="acoes-teste-gratis">
+            <button className="botao-acao" onClick={() => finalizar()}>
+              Confirmar
+            </button>
+            <button className="botao-cancelar" onClick={cancelar}>
+              Cancelar
+            </button>
+          </div>
+        )}
+      </div>
+      {mostrarModal && planoSelecionado && planoSelecionado.id !== 'teste_gratis' && (
+        <ModalPlanoSelecionado
+          plano={planoSelecionado}
+          finalizar={finalizar}
+          onClose={cancelar}
+        />
+      )}
+    </div>
+  );
+}
+
+export default EscolherPlanoCadastro;

--- a/client/src/styles/planos.css
+++ b/client/src/styles/planos.css
@@ -1,0 +1,70 @@
+.pagina-escolher-plano {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-image: url('/icones/telafundo.png');
+  background-size: cover;
+  background-position: center;
+}
+
+.painel-planos {
+  background-color: rgba(255, 255, 255, 0.9);
+  padding: 40px;
+  border-radius: 20px;
+  max-width: 900px;
+  width: 100%;
+  text-align: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.grid-planos {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.card-plano-modern {
+  background-color: #fff;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.lista-beneficios {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.lista-beneficios li + li {
+  margin-top: 4px;
+}
+
+.btn-escolher-moderno {
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: opacity 0.2s ease;
+}
+
+.btn-escolher-moderno:hover {
+  opacity: 0.9;
+}
+
+.acoes-teste-gratis {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}


### PR DESCRIPTION
## Summary
- add modern plan selection page with plan cards and modal
- style plan selection with new CSS
- register route for plan selection

## Testing
- `npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890d1d30bbc83289c1a736e6f892b1c