### PR TITLE
feat: add plan confirmation flow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Login from './pages/Auth/Login';
 import Cadastro from './pages/Auth/Cadastro';
-import VerificarCodigo from './pages/Auth/VerificarCodigo';
+import VerificarEmail from './pages/Auth/VerificarEmail';
 import EsqueciSenha from './pages/Auth/EsqueciSenha';
 import Logout from './pages/Auth/Logout';
 import EscolherPlanoCadastro from './pages/Auth/EscolherPlanoCadastro';
@@ -14,7 +14,7 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/cadastro" element={<Cadastro />} />
         <Route path="/escolher-plano" element={<EscolherPlanoCadastro />} />
-        <Route path="/verificar-codigo" element={<VerificarCodigo />} />
+        <Route path="/verificar-email" element={<VerificarEmail />} />
         <Route path="/recuperar" element={<EsqueciSenha />} />
         <Route path="/logout" element={<Logout />} />
         <Route path="/dashboard" element={<div>Login funcionou</div>} />

--- a/client/src/pages/Auth/Cadastro.jsx
+++ b/client/src/pages/Auth/Cadastro.jsx
@@ -8,9 +8,11 @@ import CarrosselLogos from "../../components/CarrosselLogos";
 
 function Cadastro() {
   const [searchParams] = useSearchParams();
-  const plano = searchParams.get('plano');
+  const planoParam = searchParams.get('plano');
+  const pagamentoParam = searchParams.get('pagamento');
   const navigate = useNavigate();
 
+  const [plano] = useState(planoParam || '');
   const [nome, setNome] = useState('');
   const [nomeFazenda, setNomeFazenda] = useState('');
   const [email, setEmail] = useState('');
@@ -19,7 +21,7 @@ function Cadastro() {
   const [confirmarSenha, setConfirmarSenha] = useState('');
   const [mostrarSenha, setMostrarSenha] = useState(false);
   const [mostrarConfirmar, setMostrarConfirmar] = useState(false);
-  const [formaPagamento, setFormaPagamento] = useState(null);
+  const [formaPagamento, setFormaPagamento] = useState(pagamentoParam || '');
   const [erro, setErro] = useState('');
 
   useEffect(() => {
@@ -34,7 +36,7 @@ function Cadastro() {
     if (senha.length < 6) return 'A senha deve ter no mínimo 6 caracteres';
     const tel = telefone.replace(/\D/g, '');
     if (tel.length < 10) return 'Telefone inválido';
-    if (plano !== 'teste_gratis' && !formaPagamento) return 'Selecione uma forma de pagamento';
+    if (plano !== 'Teste Grátis' && !formaPagamento) return 'Selecione uma forma de pagamento';
     return '';
   };
 
@@ -54,21 +56,20 @@ function Cadastro() {
         telefone,
         senha,
         plano,
-        formaPagamento: formaPagamento?.value,
+        formaPagamento,
       };
-      await api.post('/auth/register', payload);
-      localStorage.setItem('emailCadastro', email);
-      localStorage.setItem('dadosCadastro', JSON.stringify(payload));
-      navigate('/verificar-codigo');
+      await api.post('/auth/cadastrar', payload);
+      await api.post('/auth/enviar-codigo', { email });
+      navigate(`/verificar-email?email=${encodeURIComponent(email)}`);
     } catch {
       setErro('Erro no cadastro');
     }
   };
 
   const formasPagamento = [
-    { value: 'cartao', label: 'Cartão de crédito' },
-    { value: 'boleto', label: 'Boleto' },
     { value: 'pix', label: 'Pix' },
+    { value: 'boleto', label: 'Boleto' },
+    { value: 'cartao', label: 'Cartão' },
   ];
 
   const inputStyle = {
@@ -193,11 +194,11 @@ function Cadastro() {
             {mostrarConfirmar ? <EyeOff size={18} /> : <Eye size={18} />}
           </button>
         </div>
-        {plano !== 'teste_gratis' && (
+        {plano !== 'Teste Grátis' && !pagamentoParam && (
           <Select
             options={formasPagamento}
-            value={formaPagamento}
-            onChange={setFormaPagamento}
+            value={formasPagamento.find((o) => o.value === formaPagamento)}
+            onChange={(opt) => setFormaPagamento(opt.value)}
             placeholder="Forma de pagamento"
             styles={{
               control: (base) => ({

--- a/client/src/pages/Auth/EscolherPlanoCadastro.jsx
+++ b/client/src/pages/Auth/EscolherPlanoCadastro.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Gift, Star, Rocket, Crown } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import Select from 'react-select';
 import '../../styles/planos.css';
 
 const planos = [
@@ -50,11 +51,17 @@ function EscolherPlanoCadastro() {
     completo: 39.9,
   };
 
+  const opcoesPagamento = [
+    { value: 'pix', label: 'Pix' },
+    { value: 'boleto', label: 'Boleto' },
+    { value: 'cartao', label: 'Cartão' },
+  ];
+
   const navegar = useNavigate();
 
   return (
     <>
-      {mostrarModal && (
+      {mostrarModal && planoSelecionado && (
         <div
           style={{
             position: 'fixed',
@@ -77,6 +84,7 @@ function EscolherPlanoCadastro() {
               maxWidth: '400px',
               width: '90%',
               textAlign: 'center',
+              boxShadow: '0 4px 10px rgba(0,0,0,0.3)',
             }}
           >
             <h2
@@ -89,31 +97,28 @@ function EscolherPlanoCadastro() {
               Confirmar Plano
             </h2>
             <p>
-              Você selecionou o plano <strong>{planoSelecionado}</strong>.
+              Você selecionou o plano <strong>{planoSelecionado.nome}</strong>
             </p>
             <p>
-              {planoSelecionado === 'teste_gratis'
-                ? 'Esse plano é gratuito por 7 dias.'
-                : `Valor: R$ ${valoresPlano[planoSelecionado].toFixed(2)} / mês`}
+              Valor: R$
+              {valoresPlano[planoSelecionado.id]
+                .toFixed(2)
+                .replace('.', ',')}{' '}
+              / mês
             </p>
-            {planoSelecionado !== 'teste_gratis' && (
-              <select
-                value={formaPagamento}
-                onChange={(e) => setFormaPagamento(e.target.value)}
-                style={{
+            <Select
+              options={opcoesPagamento}
+              value={opcoesPagamento.find((o) => o.value === formaPagamento)}
+              onChange={(opt) => setFormaPagamento(opt.value)}
+              placeholder="Forma de pagamento"
+              styles={{
+                control: (base) => ({
+                  ...base,
                   marginTop: '10px',
-                  padding: '8px',
                   borderRadius: '10px',
-                  border: '1px solid #ccc',
-                  width: '100%',
-                }}
-              >
-                <option value="">Escolha a forma de pagamento</option>
-                <option value="pix">Pix</option>
-                <option value="boleto">Boleto</option>
-                <option value="cartao">Cartão</option>
-              </select>
-            )}
+                }),
+              }}
+            />
             <div
               style={{
                 marginTop: '20px',
@@ -135,12 +140,12 @@ function EscolherPlanoCadastro() {
               </button>
               <button
                 onClick={() => {
-                  if (planoSelecionado !== 'teste_gratis' && !formaPagamento) {
+                  if (!formaPagamento) {
                     alert('Selecione uma forma de pagamento');
                     return;
                   }
                   const queryParams = new URLSearchParams({
-                    plano: planoSelecionado,
+                    plano: planoSelecionado.nome,
                     pagamento: formaPagamento,
                   }).toString();
                   navegar(`/cadastro?${queryParams}`);
@@ -178,7 +183,8 @@ function EscolherPlanoCadastro() {
                 </ul>
                 <button
                   onClick={() => {
-                    setPlanoSelecionado(plano.id);
+                    setPlanoSelecionado(plano);
+                    setFormaPagamento('');
                     setMostrarModal(true);
                   }}
                   className="btn-escolher-moderno"

--- a/client/src/pages/Auth/VerificarEmail.jsx
+++ b/client/src/pages/Auth/VerificarEmail.jsx
@@ -1,31 +1,19 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import api from '../../api';
 
-export default function VerificarCodigo() {
+export default function VerificarEmail() {
+  const [searchParams] = useSearchParams();
+  const emailParam = searchParams.get('email') || '';
+  const [email, setEmail] = useState(emailParam);
   const [codigo, setCodigo] = useState('');
   const navigate = useNavigate();
-  const [email, setEmail] = useState('');
-
-  useEffect(() => {
-    const emailSalvo = localStorage.getItem('emailCadastro');
-    if (!emailSalvo) {
-      navigate('/cadastro');
-    } else {
-      setEmail(emailSalvo);
-    }
-  }, [navigate]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
       await api.post('/auth/verificar', { email, codigo });
-
-      // Limpa dados salvos temporariamente
-      localStorage.removeItem('emailCadastro');
-      localStorage.removeItem('dadosCadastro');
-
-      navigate('/login');
+      navigate('/');
     } catch (err) {
       alert('Código inválido ou expirado');
     }
@@ -38,17 +26,19 @@ export default function VerificarCodigo() {
     >
       <div className="bg-white p-6 rounded-lg shadow-md w-full max-w-md">
         <img src="/icon.svg" alt="Logo" className="mx-auto mb-4 w-16" />
-        <h2 className="text-xl font-bold text-center mb-4">
-          Verificar Código
-        </h2>
-        <p className="text-center text-gray-600 text-sm mb-4">
-          Um código foi enviado para: <strong>{email}</strong>
-        </p>
+        <h2 className="text-xl font-bold text-center mb-4">Verificar Email</h2>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="E-mail"
+          className="w-full px-4 py-2 border rounded-lg mb-4"
+        />
         <input
           type="text"
           value={codigo}
           onChange={(e) => setCodigo(e.target.value)}
-          placeholder="Digite o código"
+          placeholder="Código de verificação"
           className="w-full px-4 py-2 border rounded-lg mb-4"
         />
         <button


### PR DESCRIPTION
## Summary
- add confirmation modal for plan selection using react-select
- read plan and payment from query params during sign-up and send verification email
- create email verification screen and route

## Testing
- `npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891143896c083289c074b8679a34608