### PR TITLE
Add auth email verification backend

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,6 @@ DB_PASS="N@ndo1628"
 DB_HOST=localhost
 DB_PORT=5432
 PORT=3001
+
+EMAIL_REMETENTE=seuemail@gmail.com
+SENHA_REMETENTE=sua-senha-ou-senha-de-aplicativo

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,0 +1,51 @@
+const { enviarCodigoEmail } = require('../services/emailService');
+const {
+  gerarCodigo,
+  salvarCodigo,
+  verificarCodigo,
+  emailFoiVerificado
+} = require('../utils/verificacaoStorage');
+
+async function enviarCodigo(req, res) {
+  const { email } = req.body;
+  if (!email) return res.status(400).json({ erro: 'Email obrigatório' });
+
+  const codigo = gerarCodigo();
+  salvarCodigo(email, codigo);
+
+  try {
+    await enviarCodigoEmail(email, codigo);
+    res.json({ mensagem: 'Código enviado com sucesso!' });
+  } catch (err) {
+    console.error('Erro ao enviar e-mail:', err);
+    res.status(500).json({ erro: 'Erro ao enviar o código. Verifique o email do remetente.' });
+  }
+}
+
+function verificarCodigoHandler(req, res) {
+  const { email, codigo } = req.body;
+  if (!email || !codigo) return res.status(400).json({ erro: 'Email e código obrigatórios' });
+
+  const resultado = verificarCodigo(email, codigo);
+  if (!resultado.valido) return res.status(400).json({ erro: resultado.motivo });
+
+  res.json({ mensagem: 'Código verificado com sucesso!' });
+}
+
+function cadastrar(req, res) {
+  const { nome, nomeFazenda, email, telefone, senha, plano, formaPagamento } = req.body;
+
+  if (!emailFoiVerificado(email)) {
+    return res.status(403).json({ erro: 'Email ainda não verificado' });
+  }
+
+  // Aqui você salvaria no banco (Sequelize)
+  console.log('📦 Cadastro aprovado:', { nome, email });
+  res.json({ mensagem: 'Cadastro realizado com sucesso!' });
+}
+
+module.exports = {
+  enviarCodigo,
+  verificarCodigoHandler,
+  cadastrar
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const cors = require('cors');
+const bodyParser = require('body-parser');
+require('dotenv').config();
+
+const app = express();
+const PORT = 3001;
+
+app.use(cors());
+app.use(bodyParser.json());
+
+// Rotas
+const authRoutes = require('./routes/auth');
+app.use('/api/auth', authRoutes);
+
+// Rota teste
+app.get('/api', (req, res) => {
+  res.send('✅ Backend rodando!');
+});
+
+app.listen(PORT, () => {
+  console.log(`🚀 Backend rodando em http://localhost:${PORT}`);
+});

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const {
+  enviarCodigo,
+  verificarCodigoHandler,
+  cadastrar
+} = require('../controllers/authController');
+
+router.post('/enviar-codigo', enviarCodigo);
+router.post('/verificar-codigo', verificarCodigoHandler);
+router.post('/cadastrar', cadastrar);
+
+module.exports = router;

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -1,0 +1,20 @@
+const nodemailer = require('nodemailer');
+
+const transporter = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: process.env.EMAIL_REMETENTE,
+    pass: process.env.SENHA_REMETENTE
+  }
+});
+
+async function enviarCodigoEmail(destinatario, codigo) {
+  await transporter.sendMail({
+    from: process.env.EMAIL_REMETENTE,
+    to: destinatario,
+    subject: 'Código de Verificação - Gestão Leiteira',
+    html: `<p>Seu código de verificação é:</p><h2>${codigo}</h2><p>Ele expira em 10 minutos.</p>`
+  });
+}
+
+module.exports = { enviarCodigoEmail };

--- a/backend/utils/verificacaoStorage.js
+++ b/backend/utils/verificacaoStorage.js
@@ -1,0 +1,38 @@
+const codigosVerificacao = {};
+const emailsVerificados = {};
+
+function gerarCodigo() {
+  return Math.floor(100000 + Math.random() * 900000).toString();
+}
+
+function salvarCodigo(email, codigo) {
+  codigosVerificacao[email] = {
+    codigo,
+    expiraEm: Date.now() + 10 * 60 * 1000 // 10 minutos
+  };
+}
+
+function verificarCodigo(email, codigoInformado) {
+  const registro = codigosVerificacao[email];
+  if (!registro) return { valido: false, motivo: 'Código não encontrado' };
+  if (Date.now() > registro.expiraEm) {
+    delete codigosVerificacao[email];
+    return { valido: false, motivo: 'Código expirado' };
+  }
+  if (registro.codigo !== codigoInformado) return { valido: false, motivo: 'Código incorreto' };
+
+  emailsVerificados[email] = true;
+  delete codigosVerificacao[email];
+  return { valido: true };
+}
+
+function emailFoiVerificado(email) {
+  return emailsVerificados[email] === true;
+}
+
+module.exports = {
+  gerarCodigo,
+  salvarCodigo,
+  verificarCodigo,
+  emailFoiVerificado
+};


### PR DESCRIPTION
## Summary
- implement nodemailer service for sending verification codes
- add in-memory storage for codes and verified emails
- create auth controller and routes with send, verify, and register endpoints
- configure express index and environment variables

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6891425755288328914b3e4343aba023