### PR TITLE
feat: add email verification component

### DIFF
--- a/client/src/components/VerificacaoEmail.jsx
+++ b/client/src/components/VerificacaoEmail.jsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import api from '../api';
+
+export default function VerificacaoEmail({ email, setEmail, onEmailVerificado }) {
+  const [codigo, setCodigo] = useState('');
+  const [codigoEnviado, setCodigoEnviado] = useState(false);
+  const [verificado, setVerificado] = useState(false);
+  const [mensagem, setMensagem] = useState('');
+  const [carregando, setCarregando] = useState(false);
+
+  const enviarCodigo = async () => {
+    setMensagem('');
+    setCarregando(true);
+    try {
+      await api.post('/auth/enviar-codigo', { email });
+      setCodigoEnviado(true);
+      setMensagem('📩 Código enviado! Verifique seu e-mail.');
+    } catch (error) {
+      setMensagem(error.response?.data?.erro || 'Erro ao enviar código');
+    }
+    setCarregando(false);
+  };
+
+  const verificarCodigo = async () => {
+    setMensagem('');
+    setCarregando(true);
+    try {
+      await api.post('/auth/verificar-codigo', { email, codigo });
+      setVerificado(true);
+      onEmailVerificado(true);
+      setMensagem('✅ Email verificado com sucesso!');
+    } catch (error) {
+      setMensagem(error.response?.data?.erro || 'Erro ao verificar código');
+    }
+    setCarregando(false);
+  };
+
+  return (
+    <div style={{ marginTop: '20px' }}>
+      <label>E-mail:</label>
+      <input
+        type='email'
+        value={email}
+        disabled={verificado}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder='seuemail@email.com'
+      />
+      {!codigoEnviado && (
+        <button type='button' onClick={enviarCodigo} disabled={!email || carregando}>
+          {carregando ? 'Enviando...' : 'Enviar Código'}
+        </button>
+      )}
+      {codigoEnviado && !verificado && (
+        <>
+          <input
+            type='text'
+            placeholder='Digite o código'
+            value={codigo}
+            onChange={(e) => setCodigo(e.target.value)}
+            maxLength={6}
+          />
+          <button type='button' onClick={verificarCodigo} disabled={!codigo || carregando}>
+            {carregando ? 'Verificando...' : 'Verificar'}
+          </button>
+        </>
+      )}
+      {mensagem && <p style={{ marginTop: 10 }}>{mensagem}</p>}
+      {verificado && <p style={{ color: 'green' }}>✅ Email verificado</p>}
+    </div>
+  );
+}
+

--- a/client/src/pages/Auth/Cadastro.jsx
+++ b/client/src/pages/Auth/Cadastro.jsx
@@ -4,6 +4,7 @@ import Select from 'react-select';
 import InputMask from 'react-input-mask';
 import { Eye, EyeOff } from 'lucide-react';
 import api from '../../api';
+import VerificacaoEmail from '../../components/VerificacaoEmail';
 import CarrosselLogos from "../../components/CarrosselLogos";
 
 function Cadastro() {
@@ -16,6 +17,7 @@ function Cadastro() {
   const [nome, setNome] = useState('');
   const [nomeFazenda, setNomeFazenda] = useState('');
   const [email, setEmail] = useState('');
+  const [verificado, setVerificado] = useState(false);
   const [telefone, setTelefone] = useState('');
   const [senha, setSenha] = useState('');
   const [confirmarSenha, setConfirmarSenha] = useState('');
@@ -59,8 +61,7 @@ function Cadastro() {
         formaPagamento,
       };
       await api.post('/auth/cadastrar', payload);
-      await api.post('/auth/enviar-codigo', { email });
-      navigate(`/verificar-email?email=${encodeURIComponent(email)}`);
+      navigate('/');
     } catch {
       setErro('Erro no cadastro');
     }
@@ -97,6 +98,7 @@ function Cadastro() {
     telefone &&
     senha &&
     confirmarSenha &&
+    verificado &&
     (plano === 'Teste Grátis' || formaPagamento);
 
   return (
@@ -148,12 +150,10 @@ function Cadastro() {
           placeholder="Nome da fazenda"
           style={inputStyle}
         />
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="E-mail"
-          style={inputStyle}
+        <VerificacaoEmail
+          email={email}
+          setEmail={setEmail}
+          onEmailVerificado={setVerificado}
         />
         <InputMask
           mask="(99) 99999-9999"


### PR DESCRIPTION
## Summary
- add component to send/verify email codes
- use email verification on sign-up and require validated email before submitting

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6891489550fc8328a697af86168b8f60