### PR TITLE
Implement flexible auth verification and Zoho SMTP fix

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,6 @@ PORT=3001
 
 # 📧 Configurações de envio de e-mail (caso usadas no backend)
 EMAIL_REMETENTE=gestaoleiteirasmartcow@gmail.com
-EMAIL_SENHA_APP=Sm@rtcow2025
-SENHA_REMETENTE=Sm@rtcow2025
+SENHA_REMETENTE=Smartcow2025
 EMAIL_SERVICE=Zoho
-JWT_SECRET=sua_chave_jwt_segura
+JWT_SECRET=uma_chave_segura_aqui

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,115 +1,157 @@
 const bcrypt = require('bcryptjs');
-const jwt = require('jsonwebtoken');
-const fs = require('fs');
-const Usuario = require('../models/Usuario');
 const emailUtils = require('../utils/email');
 const { initDB, getDBPath } = require('../db');
+const Usuario = require('../models/Usuario');
 
 const pendentes = new Map();
-const SECRET = process.env.JWT_SECRET || 'segredo';
+const EXPIRA_MS = 10 * 60 * 1000; // 10 min
+const REENVIO_MS = 3 * 60 * 1000; // 3 min
 
-async function cadastro(req, res) {
-  const {
-    nome,
-    nomeFazenda,
-    email: endereco,
-    telefone,
-    senha,
-    plano: planoSolicitado,
-    formaPagamento,
-  } = req.body;
-
-  const codigo = Math.floor(100000 + Math.random() * 900000).toString();
-
-  if (!endereco || typeof endereco !== 'string') {
-    return res.status(400).json({ message: 'Email inválido ou não informado.' });
+function limpaExpirados() {
+  const agora = Date.now();
+  for (const [email, p] of pendentes.entries()) {
+    if (agora - p.criado_em.getTime() > EXPIRA_MS) pendentes.delete(email);
   }
+}
 
-  const dbPath = getDBPath(endereco);
+function geraCodigo() {
+  return Math.floor(100000 + Math.random() * 900000).toString();
+}
 
-  // Limpa pendências expiradas (10 min)
-  for (const [email, pend] of pendentes) {
-    if (Date.now() - pend.criado_em.getTime() > 10 * 60 * 1000) {
-      pendentes.delete(email);
-    }
-  }
-
-  if (pendentes.has(endereco)) {
-    return res.status(400).json({ message: 'Já existe uma verificação pendente para este e-mail.' });
-  }
-
-  if (fs.existsSync(dbPath)) {
-    return res.status(400).json({ message: 'Email já cadastrado.' });
-  }
-
+/**
+ * Compatível com o seu frontend:
+ * POST /api/auth/enviar-codigo
+ * Aceita:
+ *  - Mínimo: { email }
+ *  - Ideal:  { nome, nomeFazenda, email, telefone, senha, plano, formaPagamento }
+ * Guarda o que vier no Map para uso na verificação.
+ */
+async function enviarCodigo(req, res) {
   try {
-    const pendente = pendentes.get(endereco);
-    if (pendente && Date.now() - pendente.criado_em.getTime() < 3 * 60 * 1000) {
-      return res.status(400).json({ message: 'Código já enviado. Aguarde para reenviar.' });
+    limpaExpirados();
+    const {
+      nome = null,
+      nomeFazenda = null,
+      email,
+      telefone = null,
+      senha = null,
+      plano = null,
+      formaPagamento = null,
+    } = req.body || {};
+
+    if (!email || typeof email !== 'string') {
+      return res.status(400).json({ erro: 'Email inválido.' });
     }
 
-    const hash = await bcrypt.hash(senha, 10);
-    pendentes.set(endereco, {
+    // Se já existe usuário com esse e-mail, bloqueia cadastro
+    const dbPath = getDBPath(email);
+    const fs = require('fs');
+    if (fs.existsSync(dbPath)) {
+      return res.status(400).json({ erro: 'Email já cadastrado.' });
+    }
+
+    // Anti-spam de reenvio
+    const atual = pendentes.get(email);
+    if (atual && Date.now() - atual.criado_em.getTime() < REENVIO_MS) {
+      return res.status(429).json({ erro: 'Aguarde alguns minutos para reenviar o código.' });
+    }
+
+    const codigo = geraCodigo();
+    const hashSenha = senha ? await bcrypt.hash(senha, 10) : null;
+
+    pendentes.set(email, {
       codigo,
       nome,
       nomeFazenda,
       telefone,
-      senha: hash,
-      planoSolicitado,
+      senha: hashSenha, // pode ser null se veio só email (preencha antes de confirmar)
+      plano,
       formaPagamento,
       criado_em: new Date(),
     });
 
-    await emailUtils.enviarCodigo(endereco, codigo);
-    res.status(201).json({ message: 'Código enviado por e-mail.' });
-  } catch (error) {
-    console.error('Erro no cadastro:', error);
-    res.status(500).json({ error: 'Erro ao cadastrar usuário.' });
+    await emailUtils.enviarCodigo(email, codigo);
+    return res.status(200).json({ ok: true, msg: 'Código enviado.' });
+  } catch (err) {
+    console.error('Erro enviar-codigo:', err);
+    return res.status(500).json({ erro: 'Falha ao enviar código.' });
   }
 }
 
-async function verificarEmail(req, res) {
-  const { email: endereco, codigoDigitado } = req.body;
-
-  if (!endereco || typeof endereco !== 'string') {
-    return res.status(400).json({ erro: 'Email inválido.' });
-  }
-
+/**
+ * Compatível com o seu frontend:
+ * POST /api/auth/verificar-codigo
+ * Espera: { email, codigoDigitado, ...camposOpcionalmenteFaltantes }
+ * Se no passo anterior você só enviou {email}, aqui você pode enviar os demais campos.
+ */
+async function verificarCodigo(req, res) {
   try {
-    const pendente = pendentes.get(endereco);
-    if (!pendente) {
-      return res.status(400).json({ erro: 'Código não encontrado. Faça o cadastro novamente.' });
+    limpaExpirados();
+    const {
+      email,
+      codigoDigitado,
+      nome,
+      nomeFazenda,
+      telefone,
+      senha, // se não veio no passo anterior, aceita aqui
+      plano,
+      formaPagamento,
+    } = req.body || {};
+
+    if (!email || typeof email !== 'string') {
+      return res.status(400).json({ erro: 'Email inválido.' });
+    }
+    if (!codigoDigitado) {
+      return res.status(400).json({ erro: 'Código não informado.' });
     }
 
-    const expirado = Date.now() - new Date(pendente.criado_em).getTime() > 10 * 60 * 1000;
+    const pend = pendentes.get(email);
+    if (!pend) return res.status(400).json({ erro: 'Código não encontrado ou expirado.' });
+
+    const expirado = Date.now() - pend.criado_em.getTime() > EXPIRA_MS;
     if (expirado) {
-      pendentes.delete(endereco);
-      return res.status(400).json({ erro: 'Código expirado. Faça o cadastro novamente.' });
+      pendentes.delete(email);
+      return res.status(400).json({ erro: 'Código expirado. Solicite novo código.' });
     }
 
-    if (pendente.codigo !== codigoDigitado) {
+    if (pend.codigo !== codigoDigitado) {
       return res.status(400).json({ erro: 'Código incorreto.' });
     }
 
-    // Criação do usuário
-    const db = await initDB(endereco);
-    const novoUsuario = {
-      nome: pendente.nome,
-      email: endereco,
-      nomeFazenda: pendente.nomeFazenda,
-      telefone: pendente.telefone,
-      senha: pendente.senha,
-      plano: pendente.planoSolicitado,
-      formaPagamento: pendente.formaPagamento,
+    // Consolidar dados (permite completar campos aqui)
+    const final = {
+      nome: pend.nome ?? nome,
+      nomeFazenda: pend.nomeFazenda ?? nomeFazenda,
+      telefone: pend.telefone ?? telefone,
+      email,
+      senha: pend.senha, // pode vir do passo 1
+      plano: pend.plano ?? plano,
+      formaPagamento: pend.formaPagamento ?? formaPagamento,
     };
 
-    await Usuario.criar(db, novoUsuario);
-    pendentes.delete(endereco);
-    res.status(201).json({ message: 'Usuário cadastrado com sucesso.' });
-  } catch (error) {
-    console.error('Erro ao verificar e cadastrar usuário:', error);
-    res.status(500).json({ erro: 'Erro interno.' });
+    // Se a senha não foi enviada no passo 1, hashear agora
+    if (!final.senha && senha) {
+      final.senha = await bcrypt.hash(senha, 10);
+    }
+
+    // Valida mínimos obrigatórios (ajuste conforme sua regra)
+    if (!final.nome || !final.senha) {
+      return res.status(400).json({ erro: 'Dados incompletos (nome e senha são obrigatórios).' });
+    }
+
+    const db = await initDB(email);
+    await Usuario.criar(db, final);
+
+    pendentes.delete(email);
+    return res.status(201).json({ ok: true, msg: 'Usuário cadastrado com sucesso.' });
+  } catch (err) {
+    console.error('Erro verificar-codigo:', err);
+    return res.status(500).json({ erro: 'Falha ao verificar e cadastrar.' });
   }
 }
 
-module.exports = { cadastro, verificarEmail };
+module.exports = {
+  enviarCodigo,
+  verificarCodigo,
+};
+

--- a/backend/models/Usuario.js
+++ b/backend/models/Usuario.js
@@ -1,19 +1,18 @@
 async function criar(db, usuario) {
-  const query = `
+  const sql = `
     INSERT INTO usuarios (nome, email, nomeFazenda, telefone, senha, plano, formaPagamento)
     VALUES (?, ?, ?, ?, ?, ?, ?)
   `;
-  const valores = [
+  const vals = [
     usuario.nome,
     usuario.email,
-    usuario.nomeFazenda,
-    usuario.telefone,
+    usuario.nomeFazenda ?? null,
+    usuario.telefone ?? null,
     usuario.senha,
-    usuario.plano,
-    usuario.formaPagamento,
+    usuario.plano ?? null,
+    usuario.formaPagamento ?? null,
   ];
-
-  await db.run(query, valores);
+  await db.run(sql, vals);
 }
 
 module.exports = { criar };

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
-const { cadastro, verificarEmail } = require('../controllers/authController');
+const { enviarCodigo, verificarCodigo } = require('../controllers/authController');
 
-router.post('/cadastro', cadastro);
-router.post('/verificarEmail', verificarEmail);
+// Compatível com chamadas do frontend
+router.post('/enviar-codigo', enviarCodigo);
+router.post('/verificar-codigo', verificarCodigo);
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,18 +1,15 @@
 const express = require('express');
 const cors = require('cors');
-const app = express();
 require('dotenv').config();
 
+const app = express();
 app.use(cors());
 app.use(express.json());
 
-// Rota de autenticação
 const authRoutes = require('./routes/authRoutes');
-app.use('/auth', authRoutes);
-
-// Demais rotas...
+app.use('/api/auth', authRoutes);
 
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
-  console.log(`Servidor rodando na porta ${PORT}`);
+  console.log(`✅ Backend rodando em http://localhost:${PORT}`);
 });

--- a/backend/utils/email.js
+++ b/backend/utils/email.js
@@ -2,7 +2,9 @@ const nodemailer = require('nodemailer');
 require('dotenv').config();
 
 const transporter = nodemailer.createTransport({
-  service: process.env.EMAIL_SERVICE, // Zoho
+  host: 'smtp.zoho.com',
+  port: 465,
+  secure: true,
   auth: {
     user: process.env.EMAIL_REMETENTE,
     pass: process.env.SENHA_REMETENTE,
@@ -15,11 +17,11 @@ async function enviarCodigo(destinatario, codigo) {
     to: destinatario,
     subject: 'Código de Verificação - Gestão Leiteira',
     html: `
-      <div style="font-family: sans-serif; text-align: center">
-        <h2>Bem-vindo à Gestão Leiteira!</h2>
-        <p>Seu código de verificação é:</p>
+      <div style="font-family: Arial, sans-serif; text-align:center">
+        <h2>Bem-vindo!</h2>
+        <p>Seu código de verificação:</p>
         <h1>${codigo}</h1>
-        <p>O código é válido por 10 minutos.</p>
+        <p>Válido por 10 minutos.</p>
       </div>
     `,
   };


### PR DESCRIPTION
## Summary
- fix email utility to use Zoho SMTP host/port with HTML template
- add enviar/verificar codigo controllers supporting flexible payload and Map storage
- align auth routes and server mount under `/api/auth`
- allow optional user fields when creating records

## Testing
- `npm test` *(fails: Missing script: "test")*
- `NODE_PATH=server/node_modules node backend/server.js` *(fails: Cannot find module 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68967305353c8328a9e339bf1a106760