### PR TITLE
Fix Zoho SMTP env loading and improve error feedback

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -73,8 +73,11 @@ async function enviarCodigo(req, res) {
     await emailUtils.enviarCodigo(email, codigo);
     return res.status(200).json({ ok: true, msg: 'Código enviado.' });
   } catch (err) {
-    console.error('Erro enviar-codigo:', err);
-    return res.status(500).json({ erro: 'Falha ao enviar código.' });
+    console.error('Erro enviar-codigo:', err?.message || err);
+    const tip = (!process.env.EMAIL_REMETENTE || !process.env.SENHA_REMETENTE)
+      ? 'Verifique server/.env (EMAIL_REMETENTE e SENHA_REMETENTE).'
+      : 'Se usa 2FA no Zoho, gere uma senha de app e use no SENHA_REMETENTE.';
+    return res.status(500).json({ erro: 'Falha ao enviar código.', dica: tip });
   }
 }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,9 @@
+// Carrega .env o mais cedo possível
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '.env') });
+
 const express = require('express');
 const cors = require('cors');
-require('dotenv').config();
 
 const app = express();
 app.use(cors());
@@ -9,7 +12,10 @@ app.use(express.json());
 const authRoutes = require('./routes/authRoutes');
 app.use('/api/auth', authRoutes);
 
+// Healthcheck simples
+app.get('/api/health', (req, res) => res.json({ ok: true }));
+
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
-  console.log(`✅ Backend rodando em http://localhost:${PORT}`);
+  console.log(`🚀 Backend rodando em http://localhost:${PORT}`);
 });

--- a/backend/utils/email.js
+++ b/backend/utils/email.js
@@ -1,19 +1,39 @@
 const nodemailer = require('nodemailer');
-require('dotenv').config();
+// dotenv já carregado no index; aqui só usa process.env
+
+function ensureEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    throw new Error(`[CONFIG] Variável de ambiente ausente: ${name}. Crie server/.env e reinicie o server.`);
+  }
+  return v;
+}
+
+const EMAIL_REMETENTE = ensureEnv('EMAIL_REMETENTE');
+const SENHA_REMETENTE = ensureEnv('SENHA_REMETENTE');
 
 const transporter = nodemailer.createTransport({
   host: 'smtp.zoho.com',
   port: 465,
   secure: true,
   auth: {
-    user: process.env.EMAIL_REMETENTE,
-    pass: process.env.SENHA_REMETENTE,
+    user: EMAIL_REMETENTE,
+    pass: SENHA_REMETENTE,
   },
+});
+
+// Verifica conexão SMTP no boot (apenas log; não lançar erro)
+transporter.verify((err, success) => {
+  if (err) {
+    console.error('[SMTP] Falha na verificação:', err.message || err);
+  } else {
+    console.log('[SMTP] Conexão OK com Zoho.');
+  }
 });
 
 async function enviarCodigo(destinatario, codigo) {
   const mailOptions = {
-    from: process.env.EMAIL_REMETENTE,
+    from: EMAIL_REMETENTE,
     to: destinatario,
     subject: 'Código de Verificação - Gestão Leiteira',
     html: `


### PR DESCRIPTION
## Summary
- Load server environment variables early and expose `/api/health`
- Validate Zoho SMTP env vars with connection check
- Improve logging and user tips when email code fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node backend/server.js` *(fails: Cannot find module 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68967f8b37208328931d1fc31c6e2d36