### PR TITLE
feat: incluir secagem no feed de calendário

### DIFF
--- a/backend/resources/reproducao.resource.js
+++ b/backend/resources/reproducao.resource.js
@@ -612,17 +612,21 @@ router.get('/calendario', async (req, res) => {
     const secagemOffset  = Number(req.query.secagem_offset_days || 60);
 
     const itens = [];
-    // 1) Etapas de protocolo e tratamentos (já persistidos em repro_evento)
+    // 1) Eventos já persistidos em repro_evento
     const { rows: evs } = await db.query(`
-      SELECT "${EVT_DATA}" AS data, "${EVT_TIPO}" AS tipo, "${EVT_DETALHES}" AS detalhes
-      FROM "${T_EVT}"
-      WHERE "${EVT_DATA}" >= $1 AND "${EVT_DATA}" < $2
-      ${HAS_OWNER_EVT ? 'AND owner_id = $3' : ''}
+      SELECT "${EVT_DATA}" AS data, "${EVT_TIPO}" AS tipo, "${EVT_DETALHES}" AS detalhes${EVT_ANIM_COL ? `, "${EVT_ANIM_COL}" AS animal_id` : ''}
+        FROM "${T_EVT}"
+       WHERE "${EVT_DATA}" >= $1 AND "${EVT_DATA}" < $2
+       ${HAS_OWNER_EVT ? 'AND owner_id = $3' : ''}
     `, HAS_OWNER_EVT ? [start, end, ownerId] : [start, end]);
     for (const r of evs) {
       const tipo = r.tipo;
       if (tipo === 'PROTOCOLO_ETAPA' || tipo === 'TRATAMENTO') {
-        itens.push({ start: r.data, end: r.data, allDay:true, tipo: tipo==='TRATAMENTO'?'tratamento':'hormonio', title: r.detalhes?.acao || r.detalhes?.hormonio || 'Etapa', prioridadeVisual:true, origem:'repro' });
+        itens.push({ start: r.data, end: r.data, allDay:true, tipo: tipo==='TRATAMENTO'?'tratamento':'hormonio', title: r.detalhes?.acao || r.detalhes?.hormonio || 'Etapa', prioridadeVisual:true, origem:'repro', animalId: r.animal_id });
+      } else if (tipo === 'SECAGEM') {
+        itens.push({ start: r.data, end: r.data, allDay:true, tipo:'secagem', title:'Secagem', prioridadeVisual:true, origem:'repro', animalId: r.animal_id });
+      } else if (tipo === 'PARTO') {
+        itens.push({ start: r.data, end: r.data, allDay:true, tipo:'parto', title:'Parto', prioridadeVisual:true, origem:'repro', animalId: r.animal_id });
       }
     }
     // 2) Previsões DG30/DG60 a partir de IA
@@ -912,7 +916,7 @@ router.post('/secagem', async (req, res) => {
     });
 
     await atualizarAnimalCampos({ animalId: ev.animal_id, ownerId: uid, situacaoProdutiva: 'seca' }).catch(()=>{});
-
+    emitir('tarefasAtualizadas');
     res.json({ id: item.id, data: item.data, tipo: 'SECAGEM' });
   } catch (e) {
     res.status(400).json({ error:'InternalError', detail: e?.message || 'Falha ao registrar secagem' });

--- a/src/pages/Animais/FichaAnimal/FichaAnimalReproducao.jsx
+++ b/src/pages/Animais/FichaAnimal/FichaAnimalReproducao.jsx
@@ -364,7 +364,11 @@ export default function FichaAnimalReproducao({ animal }) {
         PRE_PARTO_INICIO:{ cor:'#22c55e', ic:'🌿', rot:'Início Pré-Parto' },
         PARTO_PREVISTO:  { cor:'#22c55e', ic:'👶', rot:'Parto Previsto' }
       };
-      const meta = map[tipo] || { cor:'#64748b', ic:'📌', rot:tipo };
+      let meta = map[tipo] || { cor:'#64748b', ic:'📌', rot:tipo };
+      if (tipo === 'secagem' || tipo === 'SECAGEM') {
+        const prev = raw.origem === 'prev';
+        meta = { cor:'#8b5cf6', ic: prev ? '📅' : '💧', rot: prev ? 'Secagem Prevista' : 'Secagem' };
+      }
       const tip = {
         data: raw.data,
         tipo,

--- a/src/pages/Calendario/BuscadeCalendario.jsx
+++ b/src/pages/Calendario/BuscadeCalendario.jsx
@@ -134,7 +134,23 @@ export default function useBuscadeCalendario() {
     if (!it) return null;
     const start = String(it.start || it.data || "").slice(0, 10);
     const end = String(it.end || it.start || it.data || start).slice(0, 10);
-    const tipo = String(it.tipo || "protocolo");
+    const rawTipo = String(it.tipo || "");
+    let tipo;
+    if (rawTipo === "PROTOCOLO_ETAPA") {
+      tipo = it?.detalhes?.hormonio ? "hormonio" : "protocolo";
+    } else if (rawTipo === "TRATAMENTO") {
+      tipo = "tratamento";
+    } else if (rawTipo === "PREV_DG30" || rawTipo === "PREV_DG60") {
+      tipo = "exame";
+    } else if (rawTipo === "PRE_PARTO_INICIO") {
+      tipo = "preparto";
+    } else if (rawTipo === "PARTO_PREVISTO") {
+      tipo = "parto";
+    } else if (rawTipo === "SECAGEM" || rawTipo === "SECAGEM_PREVISTA") {
+      tipo = "secagem";
+    } else {
+      tipo = rawTipo.toLowerCase() || "protocolo";
+    }
     const title =
       it.title ||
       it?.detalhes?.acao ||


### PR DESCRIPTION
## Summary
- adicionar emissão de atualização e tratamento de secagem/parto no feed de reprodução
- mapear eventos de secagem na ficha do animal
- normalizar tipos de evento ao consumir o feed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0b401f9f88328ba264b93986935f1