### PR TITLE
Integrate unified reproduction feed and secagem mapping

### DIFF
--- a/src/pages/Animais/FichaAnimal/FichaAnimalReproducao.jsx
+++ b/src/pages/Animais/FichaAnimal/FichaAnimalReproducao.jsx
@@ -362,13 +362,11 @@ export default function FichaAnimalReproducao({ animal }) {
         PREV_DG30:       { cor:'#06b6d4', ic:'🔎', rot:'Previsão DG30' },
         PREV_DG60:       { cor:'#06b6d4', ic:'🔎', rot:'Previsão DG60' },
         PRE_PARTO_INICIO:{ cor:'#22c55e', ic:'🌿', rot:'Início Pré-Parto' },
-        PARTO_PREVISTO:  { cor:'#22c55e', ic:'👶', rot:'Parto Previsto' }
+        PARTO_PREVISTO:  { cor:'#22c55e', ic:'👶', rot:'Parto Previsto' },
+        SECAGEM:         { cor:'#7e22ce', ic:'🟣', rot:'Secagem' },
+        SECAGEM_PREVISTA:{ cor:'#a78bfa', ic:'🟣', rot:'Secagem Prevista' },
       };
       let meta = map[tipo] || { cor:'#64748b', ic:'📌', rot:tipo };
-      if (tipo === 'secagem' || tipo === 'SECAGEM') {
-        const prev = raw.origem === 'prev';
-        meta = { cor:'#8b5cf6', ic: prev ? '📅' : '💧', rot: prev ? 'Secagem Prevista' : 'Secagem' };
-      }
       const tip = {
         data: raw.data,
         tipo,
@@ -541,6 +539,7 @@ export default function FichaAnimalReproducao({ animal }) {
   /* ===== Ações backend ===== */
   async function excluirEventoById(id) {
     await apiDelete(`${API_REPRO}/eventos/${encodeURIComponent(id)}`);
+    await carregarCalendario();
   }
   async function cancelarAplicacao(aplicacaoId) {
     await apiDelete(`${API_REPRO}/aplicacao/${encodeURIComponent(aplicacaoId)}`);
@@ -549,6 +548,7 @@ export default function FichaAnimalReproducao({ animal }) {
     window.dispatchEvent(new Event("registroReprodutivoAtualizado"));
     window.dispatchEvent(new Event("atualizarCalendario"));
     window.dispatchEvent(new Event("tarefasAtualizadas"));
+    await carregarCalendario();
   }
 
   function normalizaTipo(t) {

--- a/src/pages/Calendario/BuscadeCalendario.jsx
+++ b/src/pages/Calendario/BuscadeCalendario.jsx
@@ -158,6 +158,15 @@ export default function useBuscadeCalendario() {
       it?.origem_protocolo ||
       it?.resultado ||
       tipo;
+    const origemPrev = [
+      "PREV_DG30",
+      "PREV_DG60",
+      "PRE_PARTO_INICIO",
+      "PARTO_PREVISTO",
+      "SECAGEM_PREVISTA",
+    ].includes(rawTipo)
+      ? "prev"
+      : it?.origem || null;
     return {
       id: it.id || `${tipo}-${start}-${title || ""}`,
       start,
@@ -165,6 +174,7 @@ export default function useBuscadeCalendario() {
       allDay: it.allDay !== false,
       tipo,
       title,
+      origem: origemPrev,
       prioridadeVisual: it.prioridadeVisual !== false,
       animalId: it.animalId ?? it.animal_id ?? null,
       protocoloId: it.protocoloId ?? it.protocolo_id ?? null,

--- a/src/pages/Calendario/Calendario.jsx
+++ b/src/pages/Calendario/Calendario.jsx
@@ -46,6 +46,10 @@ export default function Calendario() {
     return { domNodes: [ (() => {
       const img = document.createElement("img");
       img.src = icon; img.alt = tipo; img.className = "icone-tarefa";
+      if (info.event.extendedProps?.origem === 'prev') {
+        img.style.outline = '2px dashed #9ca3af';
+        img.style.borderRadius = '6px';
+      }
       const wrap = document.createElement("div"); wrap.appendChild(img); return wrap;
     })() ] };
   };


### PR DESCRIPTION
## Summary
- use backend reproduction calendar feed and map event types
- show predicted tasks with dashed icon borders
- map secagem events in animal reproduction agenda and refresh after deletions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b5964e788328b2449910066a2464