### PR TITLE
chore: block legacy reproduction routes

### DIFF
--- a/backend/resources/animals.resource.js
+++ b/backend/resources/animals.resource.js
@@ -159,12 +159,12 @@ const cfg = {
 
 const router = express.Router();
 
-// Rotas legadas desativadas: reprodução deve ser registrada em /reproducao
-router.post('/secagem', (_req, res) => {
-  return res.status(410).json({ ok: false, message: 'Use POST /api/v1/reproducao/secagem' });
+// Bloquear rotas antigas de eventos reprodutivos (se existirem)
+router.post('/secagem', (req, res) => {
+  return res.status(410).json({ error:'Gone', message:'Use /api/v1/reproducao/secagem' });
 });
-router.post('/parto', (_req, res) => {
-  return res.status(410).json({ ok: false, message: 'Use POST /api/v1/reproducao/parto' });
+router.post('/parto', (req, res) => {
+  return res.status(410).json({ error:'Gone', message:'Use /api/v1/reproducao/parto' });
 });
 
 /* =========== Sanitização + mapeamento inteligente de LOTE =========== */


### PR DESCRIPTION
## Summary
- block old reproductive event routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0c64e87c48328bd9f310f3b4745c1