### PR TITLE
fix: respect historico column

### DIFF
--- a/src/pages/Animais/CadastroAnimal.jsx
+++ b/src/pages/Animais/CadastroAnimal.jsx
@@ -229,8 +229,9 @@ export default function CadastroAnimal({ animais = [], onAtualizar }) {
       previsao_parto: prevPartoBR || "",
       previsao_parto_iso: prevPartoISO || undefined,
 
-      // histórico estruturado (mantemos null por simplicidade)
-      historico: null,
+      // não enviar 'historico' vazio; backend só aceita se houver coluna
+      // (se precisar, preencha algo real aqui e deixe o backend decidir)
+      // historico: { meta: {} },
     };
     return payload;
   };


### PR DESCRIPTION
## Summary
- avoid writing lote, origem or valor_compra to historico when the column is missing
- reject historico field if table lacks column and enrich 400 response tips
- do not send empty historico field from CadastroAnimal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6ecbc40048328a68b2cab1eaa3919