### PR TITLE
Adjust reproduction flows

### DIFF
--- a/backend/resources/animals.resource.js
+++ b/backend/resources/animals.resource.js
@@ -198,6 +198,14 @@ const ALLOWED_KEYS = new Set([
   'status','tipo_saida','motivo_saida','observacao_saida','data_saida','valor_saida','valor_venda',
 ]);
 
+const READ_ONLY_REPRO_KEYS = new Set([
+  'ultima_ia','ultimaIa',
+  'ia_anterior','iaAnterior',
+  'parto','ultimo_parto','parto_anterior','partoAnterior',
+  'secagem_anterior','secagemAnterior',
+  'situacao_reprodutiva','situacaoReprodutiva',
+]);
+
 const aliasMap = (body) => {
   const out = { ...body };
   if (out.ultimaIa != null && out.ultima_ia == null) out.ultima_ia = out.ultimaIa;
@@ -207,6 +215,15 @@ const aliasMap = (body) => {
   if (out.previsaoPartoISO != null && out.previsao_parto_iso == null) out.previsao_parto_iso = out.previsaoPartoISO;
   return out;
 };
+
+function stripReadOnlyReproFields(body) {
+  if (!body || typeof body !== 'object') return body;
+  const out = { ...body };
+  for (const key of READ_ONLY_REPRO_KEYS) {
+    if (key in out) delete out[key];
+  }
+  return out;
+}
 
 function normalizeDatesToISO(obj) {
   const o = { ...obj };
@@ -243,6 +260,7 @@ router.use((req, res, next) => {
 
   // 2) aliases
   let clean = aliasMap(bAllowed);
+  clean = stripReadOnlyReproFields(clean);
 
   // 3) mapeia lote dinamicamente
   const lote_id_in   = clean.lote_id   ?? clean.grupo_id   ?? null;

--- a/src/api.js
+++ b/src/api.js
@@ -340,6 +340,8 @@ export const registrarPreParto = (payload) =>
   apiV1.post('/reproducao/pre-parto', payload).then((r) => r.data);
 export const registrarParto = (payload) =>
   apiV1.post('/reproducao/parto', payload).then((r) => r.data);
+export const registrarIA = (payload) =>
+  apiV1.post('/reproducao/ia', payload).then((r) => r.data);
 export const registrarDiagnostico = (payload) =>
   apiV1.post('/reproducao/diagnostico', payload).then((r) => r.data);
 


### PR DESCRIPTION
## Summary
- block IA/parto/secagem fields from being persisted directly through /animals
- keep animals table in sync when IA, parto and secagem events are registered, including via the generic /eventos endpoint
- update CadastroAnimal and Plantel to create retroactive reproduction events (including a secagem field) instead of sending reproduction data in /animals

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68c8ac7544d4832886ccb88e26b00ec7