### PR TITLE
Ensure DG endpoint returns final reproductive status

### DIFF
--- a/src/pages/Reproducao/VisaoGeral/VisaoGeral.jsx
+++ b/src/pages/Reproducao/VisaoGeral/VisaoGeral.jsx
@@ -869,27 +869,24 @@ export default function VisaoGeral({ animais: animaisProp, onCountChange }){
         const resultado=mapa[payload.dg]||"indeterminado";
         const dataISO=brToISO(payload.data)||toISODate(today());
 
-        await postDiagnosticoAPI({
+        const resp = await postDiagnosticoAPI({
           animal_id:row.id,
           resultado,
           dataISO,
           detalhes: payload.extras || {}
         });
 
-        // Atualização OTIMISTA após DG
+        // Atualização OTIMISTA após DG usando retorno do backend
         setRows(prev => prev.map(a => {
           if (a.id !== row.id) return a;
-          let previsao = a.previsao_parto;
-          if (resultado === "prenhe") {
-            const ia = parseAnyDate(a.ultima_ia);
-            if (ia) previsao = formatBR(addDays(ia, 283));
-          }
+
+          const novaSit = resp?.situacao_reprodutiva || a.situacao_reprodutiva;
+          const ppBR = resp?.previsao_parto ? isoToBR(resp.previsao_parto) : a.previsao_parto;
+
           return {
             ...a,
-            situacao_reprodutiva: (resultado === "prenhe") ? "Prenhe" :
-                                  (resultado === "vazia")   ? "Vazia"   :
-                                                               a.situacao_reprodutiva,
-            previsao_parto: previsao
+            situacao_reprodutiva: novaSit,
+            previsao_parto: ppBR,
           };
         }));
 


### PR DESCRIPTION
## Summary
- adjust POST /reproducao/diagnostico to fetch the updated reproductive situation and due date before responding
- return `{ ok, resultado, situacao_reprodutiva, previsao_parto }` from the diagnostic handler so the UI can react immediately
- update the Reproducao overview page to apply the backend response optimistically after registering a diagnostic

## Testing
- npm run build *(fails: Could not resolve "./calendariosanitario" from "src/pages/ConsumoReposicao/ConsumoReposicao.jsx")*

------
https://chatgpt.com/codex/tasks/task_e_68c9f1066efc8328ab0d4517a921084a