### PR TITLE
Return DG reproductive status immediately

### DIFF
--- a/backend/resources/reproducao.resource.js
+++ b/backend/resources/reproducao.resource.js
@@ -1410,7 +1410,7 @@ router.post('/diagnostico', async (req, res) => {
 
     await atualizarAnimalCampos(camposAnimal).catch(() => {});
 
-    let situacaoFinal = ANIM_SIT_REP ? (camposAnimal.situacaoReprodutiva ?? null) : null;
+    let situacaoFinal = camposAnimal.situacaoReprodutiva ?? null;
     let previsaoPartoFinal = camposAnimal.previsaoPartoISO ?? null;
 
     if (ANIM_ID_COL && (ANIM_SIT_REP || ANIM_PREV_PARTO)) {
@@ -1440,6 +1440,12 @@ router.post('/diagnostico', async (req, res) => {
           console.warn('[POST /reproducao/diagnostico] falha ao ler estado final:', err?.message);
         }
       }
+    }
+
+    if (typeof situacaoFinal === 'string' && situacaoFinal) {
+      const norm = normStr(situacaoFinal).trim();
+      if (norm === 'prenhe' || norm === 'prenha') situacaoFinal = 'Prenhe';
+      else if (norm === 'vazia' || norm === 'vazio') situacaoFinal = 'Vazia';
     }
 
     await client.query('COMMIT');

--- a/src/pages/Reproducao/VisaoGeral/VisaoGeral.jsx
+++ b/src/pages/Reproducao/VisaoGeral/VisaoGeral.jsx
@@ -880,8 +880,16 @@ export default function VisaoGeral({ animais: animaisProp, onCountChange }){
         setRows(prev => prev.map(a => {
           if (a.id !== row.id) return a;
 
-          const novaSit = resp?.situacao_reprodutiva || a.situacao_reprodutiva;
-          const ppBR = resp?.previsao_parto ? isoToBR(resp.previsao_parto) : a.previsao_parto;
+          // 1) usa o que o backend retornou (ideal)
+          let novaSit = resp?.situacao_reprodutiva || a.situacao_reprodutiva;
+          let ppBR = resp?.previsao_parto ? isoToBR(resp.previsao_parto) : a.previsao_parto;
+
+          // 2) fallback otimista caso o backend ainda não atualize imediatamente
+          if (!resp?.situacao_reprodutiva && resultado === "prenhe") {
+            novaSit = "Prenhe";
+            const ia = parseAnyDate(a.ultima_ia);
+            if (ia) ppBR = formatBR(addDays(ia, 283));
+          }
 
           return {
             ...a,


### PR DESCRIPTION
## Summary
- ensure the diagnóstico endpoint reads the animal state from the same table used by the list and returns the final status and due date
- normalise reproductive status strings before sending them back to the client
- add an optimistic Prenhe fallback in the reprodução overview so the grid updates immediately when the backend response lacks the new status

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f4d4d604832885bda52f24f137f2