### PR TITLE
Update ANIM_SIT_REP column candidates

### DIFF
--- a/backend/resources/reproducao.resource.js
+++ b/backend/resources/reproducao.resource.js
@@ -172,7 +172,7 @@ const HAS_CREATED_ANIM  = ANIM_COLS.has('created_at');
 // animals (campos opcionais)
 const ANIM_ID_COL = findCol(ANIM_COLS, ['id','animal_id','uuid']);
 const ANIM_SIT_REP = findCol(ANIM_COLS, [
-  'situacao_reprodutiva','sit_reprodutiva','status_reprodutivo','situacao_rep','situacao_repro','estado'
+  'situacao_reprodutiva','sit_reprodutiva','status_reprodutivo','situacao_rep','situacao_repro','situacaoReprodutiva'
 ]);
 const ANIM_SIT_PROD = findCol(ANIM_COLS, [
   'situacao_produtiva', 'sit_produtiva',


### PR DESCRIPTION
## Summary
- remove the generic estado column from the ANIM_SIT_REP search list
- include situacaoReprodutiva as an additional candidate column name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9f7e141448328b3874af9c1cb273b