### PR TITLE
Ensure diagnostico response uses computed values

### DIFF
--- a/backend/resources/reproducao.resource.js
+++ b/backend/resources/reproducao.resource.js
@@ -1504,6 +1504,16 @@ router.post('/diagnostico', async (req, res) => {
       else if (norm === 'vazia' || norm === 'vazio') situacaoFinal = 'Vazia';
     }
 
+    // Se a coluna específica não foi atualizada (por exemplo, animais recém criados),
+    // utilize os valores calculados no backend para refletir o diagnóstico informado.
+    if (!situacaoFinal) {
+      if (resultado === 'prenhe') situacaoFinal = 'Prenhe';
+      else if (resultado === 'vazia') situacaoFinal = 'Vazia';
+    }
+    if (!previsaoPartoFinal && camposAnimal.previsaoPartoISO) {
+      previsaoPartoFinal = camposAnimal.previsaoPartoISO;
+    }
+
     await client.query('COMMIT');
 
     emitir('protocolosAtivosAtualizados');


### PR DESCRIPTION
## Summary
- ensure the diagnóstico handler falls back to computed reproductive status and predicted birth date when the animal row lacks updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0e4129d88328b1fafc8bccd67557