### PR TITLE
Ajusta fallback da situação reprodutiva

### DIFF
--- a/backend/resources/reproducao.resource.js
+++ b/backend/resources/reproducao.resource.js
@@ -482,9 +482,16 @@ async function atualizarAnimalCampos({
     }
   }
 
-  if (ANIM_SIT_REP && situacaoReprodutiva) {
-    sets.push(`"${ANIM_SIT_REP}" = $${params.length + 1}`);
-    params.push(situacaoReprodutiva);
+  // Atualiza a coluna de situação reprodutiva. Se não existir coluna
+  // dedicada (ANIM_SIT_REP), usa a coluna "estado" como fallback.
+  if (situacaoReprodutiva) {
+    if (ANIM_SIT_REP) {
+      sets.push(`"${ANIM_SIT_REP}" = $${params.length + 1}`);
+      params.push(situacaoReprodutiva);
+    } else if (ANIM_ESTADO) {
+      sets.push(`"${ANIM_ESTADO}" = $${params.length + 1}`);
+      params.push(situacaoReprodutiva);
+    }
   }
 
   if (ANIM_ULT_PARTO_COL && ultimoParto !== undefined) {


### PR DESCRIPTION
## Summary
- atualiza o helper de atualização de animais para registrar a situação reprodutiva
- usa a coluna `estado` como fallback quando não existe coluna dedicada `ANIM_SIT_REP`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb441c620883288a034f954d92bf25