### PR TITLE
Normalize reproduction aliases to camelCase

### DIFF
--- a/backend/resources/animals.resource.js
+++ b/backend/resources/animals.resource.js
@@ -133,7 +133,19 @@ const candidatesList = [
   'status','tipo_saida','motivo_saida','observacao_saida','data_saida','valor_saida','valor_venda',
   'historico','created_at','updated_at'
 ];
-const listFields = candidatesList.filter(hasCol);
+const listFieldsBase = candidatesList.filter(hasCol);
+const camelAliasPairs = [
+  ['situacao_reprodutiva', 'situacaoReprodutiva'],
+  ['situacao_produtiva',  'situacaoProdutiva'],
+  ['ultima_ia',           'ultimaIa'],
+  ['previsao_parto',      'previsaoParto'],
+];
+const listFields = [
+  ...listFieldsBase,
+  ...camelAliasPairs
+    .filter(([col]) => hasCol(col))
+    .map(([col, alias]) => ({ column: col, alias })),
+];
 
 const candidatesSearch = ['numero','brinco','raca','estado','pai','mae','situacao_produtiva','situacao_reprodutiva'];
 const searchFields = candidatesSearch.filter(hasCol);


### PR DESCRIPTION
## Summary
- expose camelCase aliases for reproductive fields from the animals resource while retaining snake_case compatibility
- enhance the CRUD router to accept structured field descriptors so alias definitions are honored across list/get/create/update flows
- standardize reproduction resource queries and POST /diagnostico responses to emit camelCase keys alongside legacy snake_case
- update the reprodução Visão Geral UI to prioritize camelCase data, mirror snake_case fields locally, and handle camelCase responses from diagnostics

## Testing
- npm run build *(fails: Could not resolve "./calendariosanitario" from src/pages/ConsumoReposicao/ConsumoReposicao.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cc75dfbc4c8328ba718234df09e85a