### PR TITLE
Prioritize reproduction data in animal merge

### DIFF
--- a/src/pages/Reproducao/VisaoGeral/VisaoGeral.jsx
+++ b/src/pages/Reproducao/VisaoGeral/VisaoGeral.jsx
@@ -579,11 +579,12 @@ async function getAnimaisFromAPI(){
   for (const id of ids) {
     const A = mapAni.get(id) || {};
     const R = mapRep.get(id) || {};
-    const situacao_reprodutiva = (A.situacao_reprodutiva || R.situacao_reprodutiva || "").trim();
-    const situacao_produtiva   = (A.situacao_produtiva   || R.situacao_produtiva   || "").trim();
-    const parto                = A.parto || R.parto || "";
+    // >>> reprodução é a fonte de verdade
+    const situacao_reprodutiva = (R.situacao_reprodutiva || A.situacao_reprodutiva || "").trim();
+    const situacao_produtiva   = (R.situacao_produtiva   || A.situacao_produtiva   || "").trim();
+    const parto                = R.parto || A.parto || "";
     const ultima_ia            = R.ultima_ia || A.ultima_ia || "";
-    const previsao_parto       = A.previsao_parto || R.previsao_parto || "";
+    const previsao_parto       = (R.previsao_parto || A.previsao_parto || "").trim();
 
     const out = {
       ...(R.id ? R : A),


### PR DESCRIPTION
## Summary
- ensure reproduction API data is treated as the source of truth when merging animal records
- trim merged reproductive and productive status fields to avoid whitespace issues

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc8b65ad90832884ffb9185b08b2b4